### PR TITLE
Locales commits

### DIFF
--- a/Common/assets/locales/bs.json
+++ b/Common/assets/locales/bs.json
@@ -1,7 +1,7 @@
 {
 	"settings": "Postavke",
 	"instance_url": "Mastodonski URL primjer",
-	"url_form_needed": "URL primjer mora biti ovako: http(s)://domain.ext",
+	"url_form_needed": "URL primjer mora biti ovako: http(s)://domain.tld",
 	"short_url_checkbox": "URL precac (frama.link)",
 	"save": "Sacuvaj",
 	"options_saved": "Opcije sacuvane.",

--- a/Common/assets/locales/ca.json
+++ b/Common/assets/locales/ca.json
@@ -1,7 +1,7 @@
 {
 	"settings": "Configuració",
 	"instance_url": "URL del Mastodon",
-	"url_form_needed": "L'URL de la instància ha de ser del tipus: http(s)://domini.ext",
+	"url_form_needed": "L'URL de la instància ha de ser del tipus: http(s)://domini.tld",
 	"short_url_checkbox": "Escurça les URL (frama.link)",
 	"save": "Desa",
 	"options_saved": "S'ha desat la configuració.",

--- a/Common/assets/locales/en.json
+++ b/Common/assets/locales/en.json
@@ -1,7 +1,7 @@
 {
 	"settings": "Settings",
-	"instance_url": "Mastodon's instance URL",
-	"url_form_needed": "Instance URL must be like: http(s)://domain.ext",
+	"instance_url": "Mastodon instance URL",
+	"url_form_needed": "Instance URL must be like: http(s)://domain.tld",
 	"short_url_checkbox": "Shortcut URL (frama.link)",
 	"save": "Save",
 	"options_saved": "Options saved.",

--- a/Common/assets/locales/fr.json
+++ b/Common/assets/locales/fr.json
@@ -1,7 +1,7 @@
 {
     "settings": "Paramètres",
     "instance_url": "URL de l'instance Mastodon",
-    "url_form_needed": "L'URL de l'instance doit être de la forme : http(s)://domain.ext",
+    "url_form_needed": "L'URL de l'instance doit être de la forme : http(s)://domaine.tld",
     "short_url_checkbox": "Raccourcir les URL (frama.link)",
     "save": "Sauvegarder",
     "options_saved": "Options sauvegardées.",

--- a/Common/assets/locales/hu.json
+++ b/Common/assets/locales/hu.json
@@ -1,7 +1,7 @@
 {
 	"settings": "Beállítások",
 	"instance_url": "Mastodon példányának URL-e",
-	"url_form_needed": "A példány URL-nek ilyennek kell lennie: http(s)://domain.ext",
+	"url_form_needed": "A példány URL-nek ilyennek kell lennie: http(s)://domain.tld",
 	"short_url_checkbox": "Rövidített URL (frama.link)",
 	"save": "Mentés",
 	"options_saved": "A beállítások elmentve.",

--- a/Common/assets/locales/it.json
+++ b/Common/assets/locales/it.json
@@ -1,7 +1,7 @@
 {
 	"settings": "Impostazioni",
 	"instance_url": "URL dell'istanza Mastodon",
-	"url_form_needed": "L'URL dell'istanza deve essere del tipo: http(s)://domain.ext",
+	"url_form_needed": "L'URL dell'istanza deve essere del tipo: http(s)://domain.tld",
 	"short_url_checkbox": "URL abbreviato (frama.link)",
 	"save": "Salva",
 	"options_saved": "Opzioni salvate",

--- a/Common/assets/locales/locales.json
+++ b/Common/assets/locales/locales.json
@@ -6,7 +6,7 @@
 	"fr": "Français",
 	"it": "Italiano",
 	"hu": "Magyar",
-	"nl": "Dutch",
+	"nl": "Nederlands",
 	"no": "Norsk",
 	"oc": "Occitan",
 	"ro": "Românesc"

--- a/Common/assets/locales/locales.json
+++ b/Common/assets/locales/locales.json
@@ -6,7 +6,8 @@
 	"fr": "Français",
 	"it": "Italiano",
 	"hu": "Magyar",
-	"nl": "Neerlandais",
+	"nl": "Dutch",
+	"no": "Norsk",
 	"oc": "Occitan",
 	"ro": "Românesc"
 }

--- a/Common/assets/locales/nl.json
+++ b/Common/assets/locales/nl.json
@@ -1,7 +1,7 @@
 {
 	"settings": "Instellingen",
 	"instance_url": "Mastodon's instance-URL",
-	"url_form_needed": "Instance-URL dient er uit te zien als: http(s)://domein.ext",
+	"url_form_needed": "Instance-URL dient er uit te zien als: http(s)://domein.tld",
 	"short_url_checkbox": "Verkorte URL (frama.link)",
 	"save": "Opslaan",
 	"options_saved": "Opties opgeslagen.",

--- a/Common/assets/locales/no.json
+++ b/Common/assets/locales/no.json
@@ -1,0 +1,12 @@
+{
+    "settings": "Innstillinger",
+    "instance_url": "Mastodon-instans URL",
+    "url_form_needed": "Instansen URL må vaere som : http(s)://domain.tld",
+    "short_url_checkbox": "Forkorte URL (frama.link)",
+    "save": "Lagre endringer",
+    "options_saved": "Vellykket lagring av endringer.",
+    "mastodon_instance_opening": "Mastodon-instans åpning",
+    "start_info": "Du må sett Mastodon-instansen din før å klikk på knappe for forste gang.",
+    "language": "Språk",
+    "share_selection": "Del dette utvalg på Mastodon"
+}

--- a/Common/assets/locales/oc.json
+++ b/Common/assets/locales/oc.json
@@ -1,7 +1,7 @@
 {
     "settings": "Configuracion",
     "instance_url": "URL de l'instància a Mastodon",
-    "url_form_needed": "L'URL de l'instància deu aver la forma seguenta : http(s)://domeni.ext",
+    "url_form_needed": "L'URL de l'instància deu aver la forma seguenta : http(s)://domeni.tld",
     "short_url_checkbox": "Acorchir las URL (frama.link)",
     "save": "Salvagardar",
     "options_saved": "Opcions salvagardadas.",

--- a/Common/assets/locales/ro.json
+++ b/Common/assets/locales/ro.json
@@ -1,7 +1,7 @@
 {
 	"settings": "Setări",
 	"instance_url": "URL-ul instanței Mastodon",
-	"url_form_needed": "URL-ul instanței trebuie să fie de genul: http(s)://domeniu.ext",
+	"url_form_needed": "URL-ul instanței trebuie să fie de genul: http(s)://domeniu.tld",
 	"short_url_checkbox": "URL-ul scurtăturii (frama.link)",
 	"save": "Salvează",
 	"options_saved": "Opțiuni salvate.",


### PR DESCRIPTION
Just a small correction. You better talk about Top Level Domains then extensions. Domains are not files.
Changed "Neerlandais to Nederlands", according to sources on Wikipedia and Wiktionary
Added norwegian locale. It may need a further correction but it should be good.