### PR TITLE
Automatically list known Mastodon instances and pick the logged one

### DIFF
--- a/src/all/options.html
+++ b/src/all/options.html
@@ -21,7 +21,8 @@
 
 							<div class="form-group">
 								<label for="instanceUrl"></label>
-								<input id="instanceUrl" type="text" class="form-control" aria-describedby="instanceUrlHelp" pattern="^http(s)?://[A-z0-9\.\-\/]+[^/]$" required>
+								<input id="instanceUrl" list="instanceUrlList" type="text" class="form-control" aria-describedby="instanceUrlHelp" pattern="^http(s)?://[A-z0-9\.\-\/]+[^/]$" placeholder="https://mastodon.example.com" title="If you keep your session open in a tab we can find it automatically" required>
+								<datalist id="instanceUrlList"></datalist>
 								<span id="instanceUrlHelp" class="help-block"></span>
 								<input id="btnConnectInstance" class="btn btn-warning" type="button" value="Obtain access code">
 

--- a/src/firefox/manifest.json
+++ b/src/firefox/manifest.json
@@ -34,6 +34,8 @@
   },
   "permissions": [
     "contextMenus",
+    "cookies",
+    "<all_urls>",
     "tabs",
     "activeTab",
     "storage"


### PR DESCRIPTION
We enumerate cookies to find known instance URLs, and use the session
cookies to find the logged-in one automagically.

We need the cookies and <all_urls> permission for this.