### PR TITLE
Add shortcut key for tooting (requested in #39)

### DIFF
--- a/src/assets/scripts/popup.js
+++ b/src/assets/scripts/popup.js
@@ -117,6 +117,14 @@ function hideAlert(){
 }
 
 btnToot.addEventListener('click', toot);
+
+$(window).keydown(function(event) {
+  if(event.ctrlKey && event.keyCode == 13) { 
+    toot();
+    event.preventDefault(); 
+  }
+});
+
 btnClear.addEventListener('click', clear);
 document.addEventListener('DOMContentLoaded', init);
 


### PR DESCRIPTION
This PR add a shortcut key for sending a toot (Ctrl + Enter, as suggested by #39, which is also de the default in Mastodon and TD).

I'm not really a javascript programmer so I adapted the code from [this answer ](https://stackoverflow.com/questions/7295508/javascript-capture-browser-shortcuts-ctrlt-n-w). Any improvements are welcome.

Tested in Firefox successfully.